### PR TITLE
Adicionando suporte a SSL para envio de e-mail e melhorias na busca de produtos

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,22 @@
+# Use a imagem oficial do Python como base
+FROM python:3.9
+
+# Defina o locale no sistema
+RUN apt-get update && apt-get install -y locales locales-all
+
+# Defina o locale padrão
+ENV LANG pt_BR.UTF-8
+ENV LANGUAGE pt_BR:en
+ENV LC_ALL pt_BR.UTF-8
+
+# Defina o diretório de trabalho dentro do contêiner
+WORKDIR /app
+
+# Copie os arquivos de código fonte e o arquivo requirements.txt
+COPY . /app
+
+# Instale as dependências da aplicação
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Roda a aplicação
+CMD ["python", "html_scraping.py", "--local"]

--- a/html_scraping.py
+++ b/html_scraping.py
@@ -25,6 +25,7 @@ from retry import retry
 import logging
 from typing import List, Dict, Tuple, Any
 import json
+import time
 import concurrent.futures   
 from contexttimer import Timer  
 
@@ -454,10 +455,13 @@ if __name__ == '__main__':
         sys.exit()
 
     try:
-        with Timer() as t:
-            products_params = get_params_produtos(origem = origem)
-            logging.debug(products_params)
-            busca_OLX(products_params = products_params, paralelizar = True)
-            logging.info(f'Tempo total das buscas: {t.elapsed}s')
+        while True:
+            with Timer() as t:
+                hora_atual = time.localtime().tm_hour
+                products_params = get_params_produtos(origem = origem)
+                logging.debug(products_params)
+                busca_OLX(products_params = products_params, paralelizar = True)
+                logging.info(f'Tempo total das buscas: {t.elapsed}s')
+            time.sleep(28800)         
     except:
         logging.error(traceback.format_exc())

--- a/templates/cred.json
+++ b/templates/cred.json
@@ -5,7 +5,8 @@
         "user": "seu_email@gmail.com",
         "password":"codigo_gerado_em: https://security.google.com/settings/security/apppasswords",
         "from": "seu_email@gmail.com",
-        "to": "dest_e-mail@gmail.com"
+        "to": "dest_e-mail@gmail.com",
+        "ssl": true
     },
     "google-sheet": {
         "sheet_id": "id (pegar na url do sheet)"


### PR DESCRIPTION
### Adição de suporte a SSL para envio de e-mail:
Esta alteração adiciona suporte a SSL para o envio de e-mails no aplicativo, melhorando a segurança das comunicações. Agora, os usuários podem configurar facilmente as credenciais de e-mail no arquivo cred.json.

### Correção na estrutura de busca de produtos:
A estrutura de busca de produtos estava quebrada devido a mudanças na estrutura do site. Nesta alteração, refatorei o código relacionado à busca para se adequar à nova estrutura, garantindo que os produtos sejam encontrados corretamente, independentemente das mudanças no site.

### Adição de suporte ao Rio de Janeiro:
Para atender aos usuários no Rio de Janeiro, adicionei os dados do Rio de Janeiro nos arrays de cidade e estado.

### Passos para testar:
Utilizar os mesmos presentes no README. Para testar o envio com ou sem SSL basta alterar de TRUE para FALSE no _cred.json_ . Por padrão ele virá habilitado em conformidade com o modelo do gmail já existente.